### PR TITLE
feat(core): make cards be possible to return with study sessions

### DIFF
--- a/__tests__/domain/use-cases/deck/find-deck-by-id-and-user.usecase.spec.ts
+++ b/__tests__/domain/use-cases/deck/find-deck-by-id-and-user.usecase.spec.ts
@@ -9,6 +9,7 @@ import {
   validDeckProps,
   validDeckWithCardsProps,
 } from "__tests__/@support/fixtures/deck.fixtures";
+import { mockCardRepository } from "__tests__/@support/mocks/repositories/card-repository.mock";
 import { mockDeckRepository } from "__tests__/@support/mocks/repositories/deck-repository.mock";
 
 import { Deck } from "@/domain/entities/deck";
@@ -22,14 +23,18 @@ describe("FindDeckByIdAndUserUseCase", () => {
   const userId = "user-123";
 
   beforeEach(() => {
-    useCase = new FindDeckByIdAndUserUseCase(mockDeckRepository);
+    useCase = new FindDeckByIdAndUserUseCase(mockDeckRepository, mockCardRepository);
     vi.useFakeTimers();
     generateIdMock.mockReturnValue(mockId);
 
     mockDeck = new Deck(validDeckProps);
-    mockDeckWithCards = new Deck(validDeckWithCardsProps);
+    mockDeckWithCards = new Deck({
+      ...validDeckWithCardsProps,
+      cards: [...validDeckWithCardsProps.cards]
+    });
 
     mockDeckRepository.findByIdAndUserId.mockResolvedValue(mockDeck);
+    mockCardRepository.findByDeckId.mockResolvedValue(mockDeckWithCards.cards);
 
     vi.clearAllMocks();
   });
@@ -81,9 +86,13 @@ describe("FindDeckByIdAndUserUseCase", () => {
 
     it("should return deck with cards when cards are present", async () => {
       const request = { id: mockId, userId };
-      mockDeckRepository.findByIdAndUserId.mockResolvedValueOnce(
-        mockDeckWithCards
-      );
+      const deckForTest = new Deck({
+        ...validDeckWithCardsProps,
+        cards: []
+      });
+
+      mockDeckRepository.findByIdAndUserId.mockResolvedValueOnce(deckForTest);
+      mockCardRepository.findByDeckId.mockResolvedValueOnce(validDeckWithCardsProps.cards);
 
       const result = await useCase.execute(request);
 
@@ -91,7 +100,6 @@ describe("FindDeckByIdAndUserUseCase", () => {
         mockId,
         userId
       );
-      expect(result).toEqual(mockDeckWithCards);
       expect(result.cards.length).toBe(2);
     });
   });
@@ -131,9 +139,13 @@ describe("FindDeckByIdAndUserUseCase", () => {
 
     it("Given a deck with cards, When execute is called, Then the deck with cards is returned", async () => {
       const request = { id: mockId, userId };
-      mockDeckRepository.findByIdAndUserId.mockResolvedValueOnce(
-        mockDeckWithCards
-      );
+      const deckForTest = new Deck({
+        ...validDeckWithCardsProps,
+        cards: []
+      });
+
+      mockDeckRepository.findByIdAndUserId.mockResolvedValueOnce(deckForTest);
+      mockCardRepository.findByDeckId.mockResolvedValueOnce(validDeckWithCardsProps.cards);
 
       const result = await useCase.execute(request);
 

--- a/__tests__/domain/use-cases/study-session/find-study-sessions-by-user.usecase.spec.ts
+++ b/__tests__/domain/use-cases/study-session/find-study-sessions-by-user.usecase.spec.ts
@@ -5,21 +5,47 @@ import {
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { mockCardRepository } from "__tests__/@support/mocks/repositories/card-repository.mock";
+import { mockDeckRepository } from "__tests__/@support/mocks/repositories/deck-repository.mock";
 import { mockStudySessionRepository } from "__tests__/@support/mocks/repositories/study-session-repository.mock";
+import { validCardProps } from "__tests__/@support/fixtures/card.fixtures";
 
+import { StudyMode, StudyModeEnum } from "@/domain/value-objects";
+import { Card } from "@/domain/entities/card";
+import { Deck } from "@/domain/entities/deck";
 import { FindStudySessionsByUserUseCase } from "@/domain/use-cases/study-session/find-study-sessions-by-user.usecase";
-import { StudyModeEnum } from "@/domain/value-objects";
 import { StudySession } from "@/domain/entities/study-session";
 
 describe("FindStudySessionsByUserUseCase", () => {
   let useCase: FindStudySessionsByUserUseCase;
   let mockStudySessions: StudySession[];
+  let mockDeck1: Deck;
+  let mockDeck2: Deck;
+  let mockCards: Card[]
   const userId = "user-123";
 
   beforeEach(() => {
-    useCase = new FindStudySessionsByUserUseCase(mockStudySessionRepository);
+    useCase = new FindStudySessionsByUserUseCase(mockStudySessionRepository, mockDeckRepository, mockCardRepository);
     vi.useFakeTimers();
     generateIdMock.mockReturnValue(mockId);
+
+    mockDeck1 = new Deck({
+      id: "deck-1",
+      userId,
+      title: "Deck 1",
+      description: "Deck 1 description",
+      studyMode: new StudyMode(StudyModeEnum.FLASHCARD),
+    });
+
+    mockDeck2 = new Deck({
+      id: "deck-2",
+      userId,
+      title: "Deck 2",
+      description: "Deck 2 description",
+      studyMode: new StudyMode(StudyModeEnum.FLASHCARD),
+    });
+
+    mockCards = [new Card({...validCardProps, deckId: mockDeck1.id})]
 
     mockStudySessions = [
       new StudySession({
@@ -28,6 +54,7 @@ describe("FindStudySessionsByUserUseCase", () => {
         endTime: new Date().toISOString(),
         studyMode: StudyModeEnum.MULTIPLE_CHOICE,
         userId,
+        deck: mockDeck1,
       }),
       new StudySession({
         deckId: "deck-2",
@@ -35,12 +62,15 @@ describe("FindStudySessionsByUserUseCase", () => {
         endTime: new Date().toISOString(),
         studyMode: StudyModeEnum.FLASHCARD,
         userId,
+        deck: mockDeck2,
       }),
     ];
 
     mockStudySessionRepository.findByUserId.mockResolvedValue(
       mockStudySessions
     );
+    mockDeckRepository.findAllByUser.mockResolvedValue([mockDeck1, mockDeck2]);
+    mockCardRepository.findByDeckIds.mockResolvedValue([mockCards])
 
     vi.clearAllMocks();
   });
@@ -55,6 +85,7 @@ describe("FindStudySessionsByUserUseCase", () => {
       const request = {
         userId,
       };
+      console.log({request})
 
       const result = await useCase.execute(request);
 
@@ -95,6 +126,20 @@ describe("FindStudySessionsByUserUseCase", () => {
       expect(mockStudySessionRepository.findByUserId).toHaveBeenCalledWith(
         userId
       );
+    });
+
+    it("should fetch study sessions with decks", async () => {
+      const request = {
+        userId,
+      };
+
+      const result = await useCase.execute(request);
+
+      expect(mockStudySessionRepository.findByUserId).toHaveBeenCalledWith(
+        userId
+      );
+      expect(result).toEqual(mockStudySessions);
+      expect(result).toHaveLength(2);
     });
   });
 
@@ -138,6 +183,17 @@ describe("FindStudySessionsByUserUseCase", () => {
       expect(mockStudySessionRepository.findByUserId).toHaveBeenCalledWith(
         userId
       );
+    });
+
+    it("Given a user with study sessions and decks, When execute is called, Then return study sessions with decks", async () => {
+      const request = {
+        userId,
+      };
+
+      const result = await useCase.execute(request);
+
+      expect(result).toEqual(mockStudySessions);
+      expect(result).toHaveLength(2);
     });
   });
 });

--- a/src/domain/entities/study-session.ts
+++ b/src/domain/entities/study-session.ts
@@ -4,6 +4,8 @@ import { StudySessionValidationError } from '@/domain/errors/study-session/study
 
 import { generateId } from '@/shared/utils/generate-id';
 
+import { Deck } from './deck';
+
 interface StudySessionProps {
   id?: string;
   deckId: string;
@@ -11,6 +13,7 @@ interface StudySessionProps {
   startTime: string;
   endTime?: string | null;
   studyMode: StudyModeEnum;
+  deck?: Deck;
   createdAt?: string;
   updatedAt?: string;
 }
@@ -22,6 +25,7 @@ export class StudySession {
   public startTime: string;
   public endTime?: string | null;
   public studyMode: StudyModeEnum;
+  public deck?: Deck;
   public readonly createdAt: string;
   public updatedAt: string;
 
@@ -34,6 +38,7 @@ export class StudySession {
     this.startTime = props.startTime;
     this.endTime = props.endTime;
     this.studyMode = props.studyMode;
+    this.deck = props.deck;
 
     this.createdAt = props.createdAt ?? new Date().toISOString();
     this.updatedAt = props.updatedAt ?? this.createdAt;

--- a/src/domain/use-cases/deck/find-deck-by-id-and-user.usecase.ts
+++ b/src/domain/use-cases/deck/find-deck-by-id-and-user.usecase.ts
@@ -1,6 +1,6 @@
+import { CardRepository, DeckRepository } from "@/domain/interfaces/repositories";
 import { Deck } from "@/domain/entities/deck";
 import { DeckNotFoundError } from "@/domain/errors/deck/deck-not-found-error";
-import { DeckRepository } from "@/domain/interfaces/repositories";
 
 interface FindDeckByIdAndUserRequest {
   id: string;
@@ -10,7 +10,10 @@ interface FindDeckByIdAndUserRequest {
 type FindDeckByIdAndUserResponse = Deck;
 
 export class FindDeckByIdAndUserUseCase {
-  constructor(private readonly deckRepository: DeckRepository) {}
+  constructor(
+    private readonly deckRepository: DeckRepository,
+    private readonly cardRepository: CardRepository
+  ) {}
 
   async execute(
     request: FindDeckByIdAndUserRequest
@@ -30,6 +33,10 @@ export class FindDeckByIdAndUserUseCase {
       );
       throw new DeckNotFoundError(request.id, request.userId);
     }
+
+    const cards = await this.cardRepository.findByDeckId(request.id);
+
+    deck.addCards(cards);
 
     console.log(`Found deck: ${deck.title} with ${deck.cards.length} cards`);
     return deck;

--- a/src/domain/use-cases/deck/update-deck.usecase.ts
+++ b/src/domain/use-cases/deck/update-deck.usecase.ts
@@ -22,7 +22,7 @@ export class UpdateDeckUseCase {
 
   async execute(request: UpdateDeckRequest): Promise<UpdateDeckResponse> {
     console.log(
-      `Starting UpdateDeckUseCase for id: ${request.id}, userId: ${request.userId}`
+      `Starting UpdateDeckUseCase for id: ${request.id}, userId: ${request.userId}, data: ${JSON.stringify(request.data, null, 2)}`
     );
 
     const deck = await this.deckRepository.findByIdAndUserId(

--- a/src/domain/use-cases/study-session/find-study-sessions-by-user.usecase.ts
+++ b/src/domain/use-cases/study-session/find-study-sessions-by-user.usecase.ts
@@ -1,5 +1,7 @@
+import { CardRepository, DeckRepository, StudySessionRepository } from '@/domain/interfaces/repositories';
+import { Card } from '@/domain/entities/card';
+import { Deck } from '@/domain/entities/deck';
 import { StudySession } from '@/domain/entities/study-session';
-import { StudySessionRepository } from '@/domain/interfaces/repositories';
 
 interface FindStudySessionsByUserRequest {
   userId: string;
@@ -8,7 +10,11 @@ interface FindStudySessionsByUserRequest {
 type FindStudySessionsByUserResponse = StudySession[];
 
 export class FindStudySessionsByUserUseCase {
-  constructor(private readonly studySessionRepository: StudySessionRepository) {}
+  constructor(
+    private readonly studySessionRepository: StudySessionRepository,
+    private readonly deckRepository: DeckRepository,
+    private readonly cardRepository: CardRepository,
+  ) {}
 
   async execute(request: FindStudySessionsByUserRequest): Promise<FindStudySessionsByUserResponse> {
     console.log(`Starting FindStudySessionsByUserUseCase for userId: ${request.userId}`);
@@ -16,6 +22,26 @@ export class FindStudySessionsByUserUseCase {
     const studySessions = await this.studySessionRepository.findByUserId(request.userId);
 
     console.log(`Found ${studySessions.length} study sessions for user ${request.userId}`);
-    return studySessions;
+
+    const decks = await this.deckRepository.findAllByUser(request.userId);
+    const cards = await this.cardRepository.findByDeckIds(decks.map((deck) => deck.id));
+
+    console.log({decks, cards})
+
+    const decksWithCards = decks.map((deck) => {
+      const cardsForDeck = cards.filter((card: Card) => card.deckId === deck.id);
+      return new Deck({
+        ...deck,
+        cards: cardsForDeck,
+      });
+    });
+
+    return studySessions.map((session) => {
+      const deck = decksWithCards.find((deck) => deck.id === session.deckId);
+      return new StudySession({
+        ...session,
+        deck,
+      });
+    });
   }
 }

--- a/src/infrastructure/repository/dynamodb/schemas/study-session.schema.ts
+++ b/src/infrastructure/repository/dynamodb/schemas/study-session.schema.ts
@@ -87,7 +87,6 @@ export class StudySessionDynamoSchema implements StudySessionDynamoItem {
   }
 
   static fromDynamoItem(item: Record<string, AttributeValue>): StudySession {
-    console.log("item", item);
     const studySession = unmarshall(item);
 
     return new StudySession({

--- a/src/main/factories/use-cases/decks/find-deck-by-id-and-user.use-case.factory.ts
+++ b/src/main/factories/use-cases/decks/find-deck-by-id-and-user.use-case.factory.ts
@@ -1,8 +1,9 @@
 import { FindDeckByIdAndUserUseCase } from "@/domain/use-cases/deck/find-deck-by-id-and-user.usecase";
 
-import { deckRepositoryFactory } from "@/main/factories/repositories/dynamodb";
+import { cardRepositoryFactory, deckRepositoryFactory } from "@/main/factories/repositories/dynamodb";
 
 export const findDeckByIdAndUserUseCaseFactory = () => {
   const deckRepository = deckRepositoryFactory();
-  return new FindDeckByIdAndUserUseCase(deckRepository);
+  const cardRepository = cardRepositoryFactory();
+  return new FindDeckByIdAndUserUseCase(deckRepository, cardRepository);
 };

--- a/src/main/factories/use-cases/study-sessions/find-study-sessions-by-user.use-case.factory.ts
+++ b/src/main/factories/use-cases/study-sessions/find-study-sessions-by-user.use-case.factory.ts
@@ -1,9 +1,11 @@
 import { FindStudySessionsByUserUseCase } from "@/domain/use-cases/study-session/find-study-sessions-by-user.usecase";
 
-import { studySessionRepositoryFactory } from "@/main/factories/repositories/dynamodb";
+import { cardRepositoryFactory, deckRepositoryFactory, studySessionRepositoryFactory } from "@/main/factories/repositories/dynamodb";
 
 export const findStudySessionsByUserUseCaseFactory = () => {
   const studySessionRepository = studySessionRepositoryFactory();
+  const deckRepository = deckRepositoryFactory();
+  const cardRepository = cardRepositoryFactory();
 
-  return new FindStudySessionsByUserUseCase(studySessionRepository);
+  return new FindStudySessionsByUserUseCase(studySessionRepository, deckRepository, cardRepository);
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Study sessions now include detailed deck information, with each deck containing its associated cards.
  - Deck retrieval now returns decks with their corresponding cards included.

- **Bug Fixes**
  - Removed unnecessary debug logging from study session data processing.

- **Tests**
  - Expanded test coverage to ensure study sessions and decks are correctly populated with associated cards and deck data.

- **Chores**
  - Improved logging for deck updates to provide more detailed request information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->